### PR TITLE
Fix typos found by codespell; Add zh_CN translation to desktop file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,4 +14,4 @@ The author of the Multitran plugin and KDE 4 plasmoid:
 QStarDict uses the Oxygen icons (http://oxygen-icons.org).
 
 The QStarDict icon is taken from an old revision of Oxygen Icons, originally
-it was commited to KDE SVN repository by Jeff Cooper <jeff.cooper@kdemail.net>.
+it was committed to KDE SVN repository by Jeff Cooper <jeff.cooper@kdemail.net>.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ If you want to compile it yourself install Qt4 and GLib2 development files and r
     [sudo] make install
     
 More information about installation:
-* [GNU/Linux](https://github.com/therussianphysicist/qstardict/blob/master/INSTALL)
-* [macOS](https://github.com/therussianphysicist/qstardict/blob/master/README.MACOS)
-* [Windows](https://github.com/therussianphysicist/qstardict/blob/master/README.WINDOWS)
+* [GNU/Linux](https://github.com/a-rodin/qstardict/blob/master/INSTALL)
+* [macOS](https://github.com/a-rodin/qstardict/blob/master/README.MACOS)
+* [Windows](https://github.com/a-rodin/qstardict/blob/master/README.WINDOWS)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ is similar to StarDict.
 ### Installation ###
 QStarDict is available in Ubuntu, Debian and other distros repositories. 
 
-If you want to compile it youself install Qt4 and GLib2 development files and run in the project's directory
+If you want to compile it yourself install Qt4 and GLib2 development files and run in the project's directory
 
     qmake INSTALL_PREFIX=<your install prefix, /usr by default>
     make

--- a/plugins/dictplugin.h
+++ b/plugins/dictplugin.h
@@ -48,7 +48,7 @@ public:
         None          = 0x00,
         /**
          * Dictionary plugin can search for similar words using
-         * fuzzy algoritms.
+         * fuzzy algorithms.
          */
         SearchSimilar = 0x01,
     };

--- a/plugins/stardict/settingsdialog.ui
+++ b/plugins/stardict/settingsdialog.ui
@@ -22,7 +22,7 @@
       <item row="0" column="0" >
        <widget class="QCheckBox" name="reformatListsBox" >
         <property name="toolTip" >
-         <string>If enabled all lists in translation wil be formated using HTML &lt;li> tag (may be slow)</string>
+         <string>If enabled, all lists in translation will be formatted using HTML &lt;li> tag (may be slow)</string>
         </property>
         <property name="text" >
          <string>Reformat lists</string>

--- a/qstardict/pluginmanager.cpp
+++ b/qstardict/pluginmanager.cpp
@@ -28,7 +28,7 @@ Plugins priority:
    AppInfo::appPluginsDirs() return directories in priority order
    (most prioretized first)
    If there are two plugins with the same id in some directory,
-   the one with more recent modification time will be choosen.
+   the one with more recent modification time will be chosen.
 2) Plugins have load priority
    To decide which plugin to load first.
 
@@ -494,7 +494,7 @@ bool PluginManager::Plugin::unload()
     QString fileName = loader->fileName();
     if (loader->unload()) {
         delete loader;
-        // probably Qt bug but "instance" method does't work after unload. So recreate loader.
+        // probably Qt bug but "instance" method doesn't work after unload. So recreate loader.
         loader = new QPluginLoader(fileName);
         return true;
     }

--- a/qstardict/qstardict.desktop
+++ b/qstardict/qstardict.desktop
@@ -1,12 +1,16 @@
 [Desktop Entry]
 Version=1.0
 Comment=QStarDict is Qt version of StarDict
+Comment[zh_CN]=Stardict 的 Qt 版本
 Exec=qstardict
 GenericName=Dictionary
+GenericName[zh_CN]=词典
 Icon=qstardict
 Name=QStarDict
 Type=Application
 Categories=Qt;Dictionary;Utility;
+Keywords=dictionary;stardict;
+Keywords[zh_CN]=dictionary;stardict;星际译王;
 Name[ru]=QStarDict
 GenericName[ru]=Словарь
 Name[tr]=QStarDict

--- a/qstardict/settingsdialog.ui
+++ b/qstardict/settingsdialog.ui
@@ -103,7 +103,7 @@
          <item>
           <widget class="QLineEdit" name="speechCmdEdit">
            <property name="toolTip">
-            <string>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be writen to stdin of speech process.</string>
+            <string>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be written to stdin of speech process.</string>
            </property>
           </widget>
          </item>
@@ -461,7 +461,7 @@
        <item row="1" column="0">
         <widget class="QGroupBox" name="groupBox_2">
          <property name="title">
-          <string>Apperance</string>
+          <string>Appearance</string>
          </property>
          <layout class="QGridLayout">
           <property name="leftMargin">
@@ -622,7 +622,7 @@
      </widget>
      <widget class="QWidget" name="tab">
       <attribute name="title">
-       <string>Apperance</string>
+       <string>Appearance</string>
       </attribute>
       <layout class="QGridLayout">
        <item row="0" column="0">

--- a/qstardict/translations/qstardict-bg_BG.ts
+++ b/qstardict/translations/qstardict-bg_BG.ts
@@ -422,7 +422,7 @@
     </message>
     <message>
         <location filename="../settingsdialog.ui" line="88"/>
-        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be writen to stdin of speech process.</source>
+        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be written to stdin of speech process.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -554,7 +554,7 @@
     <message>
         <location filename="../settingsdialog.ui" line="452"/>
         <location filename="../settingsdialog.ui" line="577"/>
-        <source>Apperance</source>
+        <source>Appearance</source>
         <translation type="unfinished">Изглед</translation>
     </message>
     <message>

--- a/qstardict/translations/qstardict-cs_CZ.ts
+++ b/qstardict/translations/qstardict-cs_CZ.ts
@@ -422,7 +422,7 @@
     </message>
     <message>
         <location filename="../settingsdialog.ui" line="88"/>
-        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be writen to stdin of speech process.</source>
+        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be written to stdin of speech process.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -555,7 +555,7 @@ potom co kurzor opustí výběr</translation>
     <message>
         <location filename="../settingsdialog.ui" line="452"/>
         <location filename="../settingsdialog.ui" line="577"/>
-        <source>Apperance</source>
+        <source>Appearance</source>
         <translation type="unfinished">Vzhled</translation>
     </message>
     <message>

--- a/qstardict/translations/qstardict-de_DE.ts
+++ b/qstardict/translations/qstardict-de_DE.ts
@@ -422,7 +422,7 @@
     </message>
     <message>
         <location filename="../settingsdialog.ui" line="88"/>
-        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be writen to stdin of speech process.</source>
+        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be written to stdin of speech process.</source>
         <translation>Geben Sie das Kommando für das Ausspracheprogramm ein.&lt;br&gt;Falls das Kommando &quot;%s&quot; enthält, wird dies durch das Wort ersetzt, andernfalls wird das Wort auf die stdin des Sprachprozesses geschrieben.</translation>
     </message>
     <message>
@@ -554,7 +554,7 @@
     <message>
         <location filename="../settingsdialog.ui" line="452"/>
         <location filename="../settingsdialog.ui" line="577"/>
-        <source>Apperance</source>
+        <source>Appearance</source>
         <translation>Erscheinungsbild</translation>
     </message>
     <message>

--- a/qstardict/translations/qstardict-es_ES.ts
+++ b/qstardict/translations/qstardict-es_ES.ts
@@ -462,7 +462,7 @@
     </message>
     <message>
         <location filename="../settingsdialog.ui" line="88"/>
-        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be writen to stdin of speech process.</source>
+        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be written to stdin of speech process.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -599,7 +599,7 @@
     <message>
         <location filename="../settingsdialog.ui" line="452"/>
         <location filename="../settingsdialog.ui" line="577"/>
-        <source>Apperance</source>
+        <source>Appearance</source>
         <translation>Apariencia</translation>
     </message>
     <message>

--- a/qstardict/translations/qstardict-fr_FR.ts
+++ b/qstardict/translations/qstardict-fr_FR.ts
@@ -422,7 +422,7 @@
     </message>
     <message>
         <location filename="../settingsdialog.ui" line="88"/>
-        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be writen to stdin of speech process.</source>
+        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be written to stdin of speech process.</source>
         <translation>Veuillez entrer la commande à executer pour la prononciation des mots. &lt;br&gt;Si la commande contient la chaine de caractère &quot;%s&quot;, celle-ci sera remplacée par le mot à prononcer sinon le mot sera envoyé à la sortie standard du processus lancé (stdin).</translation>
     </message>
     <message>
@@ -554,7 +554,7 @@
     <message>
         <location filename="../settingsdialog.ui" line="452"/>
         <location filename="../settingsdialog.ui" line="577"/>
-        <source>Apperance</source>
+        <source>Appearance</source>
         <translation>Apparence</translation>
     </message>
     <message>

--- a/qstardict/translations/qstardict-he_IL.ts
+++ b/qstardict/translations/qstardict-he_IL.ts
@@ -423,7 +423,7 @@
     </message>
     <message>
         <location filename="../settingsdialog.ui" line="88"/>
-        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be writen to stdin of speech process.</source>
+        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be written to stdin of speech process.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -555,7 +555,7 @@
     <message>
         <location filename="../settingsdialog.ui" line="452"/>
         <location filename="../settingsdialog.ui" line="577"/>
-        <source>Apperance</source>
+        <source>Appearance</source>
         <translation>הופעה</translation>
     </message>
     <message>

--- a/qstardict/translations/qstardict-it_IT.ts
+++ b/qstardict/translations/qstardict-it_IT.ts
@@ -422,7 +422,7 @@
     </message>
     <message>
         <location filename="../settingsdialog.ui" line="88"/>
-        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be writen to stdin of speech process.</source>
+        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be written to stdin of speech process.</source>
         <translation>Inserisci il comando per il programma di pronuncia.&lt;br&gt;Se il comando contiene &quot;%s&quot; la parola verrà sostituita, altrimenti la parola sarà scritta nello stdin del processo di pronuncia.</translation>
     </message>
     <message>
@@ -554,7 +554,7 @@
     <message>
         <location filename="../settingsdialog.ui" line="452"/>
         <location filename="../settingsdialog.ui" line="577"/>
-        <source>Apperance</source>
+        <source>Appearance</source>
         <translation>Aspetto</translation>
     </message>
     <message>

--- a/qstardict/translations/qstardict-lt_LT.ts
+++ b/qstardict/translations/qstardict-lt_LT.ts
@@ -422,7 +422,7 @@
     </message>
     <message>
         <location filename="../settingsdialog.ui" line="88"/>
-        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be writen to stdin of speech process.</source>
+        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be written to stdin of speech process.</source>
         <translation>Įveskite komandą, naudojamą žodžių ištarimui.&lt;br&gt;Jei komanda turi reiškinį „%s“, jis bus pakeistas ištarsimu žodžiu, preišingu atveju žodis bus prirašytas komandos gale (stdin).</translation>
     </message>
     <message>
@@ -554,7 +554,7 @@
     <message>
         <location filename="../settingsdialog.ui" line="452"/>
         <location filename="../settingsdialog.ui" line="577"/>
-        <source>Apperance</source>
+        <source>Appearance</source>
         <translation>Išvaizda</translation>
     </message>
     <message>

--- a/qstardict/translations/qstardict-pl_PL.ts
+++ b/qstardict/translations/qstardict-pl_PL.ts
@@ -426,7 +426,7 @@
     </message>
     <message>
         <location filename="../settingsdialog.ui" line="88"/>
-        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be writen to stdin of speech process.</source>
+        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be written to stdin of speech process.</source>
         <translation>Wpisz komendę dla syntezatora mowy.&lt;br&gt;Jeśli komenda zawiera &quot;%s&quot; to będzie ona zastąpiona słowem lub słowo zostanie zapisane do stdin procesu mówienia.</translation>
     </message>
     <message>
@@ -558,7 +558,7 @@
     <message>
         <location filename="../settingsdialog.ui" line="452"/>
         <location filename="../settingsdialog.ui" line="577"/>
-        <source>Apperance</source>
+        <source>Appearance</source>
         <translation>Wygląd</translation>
     </message>
     <message>

--- a/qstardict/translations/qstardict-pt_BR.ts
+++ b/qstardict/translations/qstardict-pt_BR.ts
@@ -422,7 +422,7 @@
     </message>
     <message>
         <location filename="../settingsdialog.ui" line="88"/>
-        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be writen to stdin of speech process.</source>
+        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be written to stdin of speech process.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -554,7 +554,7 @@
     <message>
         <location filename="../settingsdialog.ui" line="452"/>
         <location filename="../settingsdialog.ui" line="577"/>
-        <source>Apperance</source>
+        <source>Appearance</source>
         <translation type="unfinished">Aparencia</translation>
     </message>
     <message>

--- a/qstardict/translations/qstardict-ru_RU.ts
+++ b/qstardict/translations/qstardict-ru_RU.ts
@@ -422,7 +422,7 @@
     </message>
     <message>
         <location filename="../settingsdialog.ui" line="88"/>
-        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be writen to stdin of speech process.</source>
+        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be written to stdin of speech process.</source>
         <translation>Введите команду для запуска программы.&lt;br&gt;Если команда содержит выражение &quot;%s&quot;, оно будет заменено на слово; иначе слово будет записано в стандартный поток ввода процесса.</translation>
     </message>
     <message>
@@ -554,7 +554,7 @@
     <message>
         <location filename="../settingsdialog.ui" line="452"/>
         <location filename="../settingsdialog.ui" line="577"/>
-        <source>Apperance</source>
+        <source>Appearance</source>
         <translation>Внешний вид</translation>
     </message>
     <message>

--- a/qstardict/translations/qstardict-ua_UA.ts
+++ b/qstardict/translations/qstardict-ua_UA.ts
@@ -422,7 +422,7 @@
     </message>
     <message>
         <location filename="../settingsdialog.ui" line="88"/>
-        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be writen to stdin of speech process.</source>
+        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be written to stdin of speech process.</source>
         <translation type="unfinished">Введіть команду для розмовної програми. &lt;br&gt;Якщо команда містить &quot;%s&quot; це буде замінено словом, інaкше слово буде записано на stdin.</translation>
     </message>
     <message>
@@ -554,7 +554,7 @@
     <message>
         <location filename="../settingsdialog.ui" line="452"/>
         <location filename="../settingsdialog.ui" line="577"/>
-        <source>Apperance</source>
+        <source>Appearance</source>
         <translation type="unfinished">Зовнiшнiй вигляд</translation>
     </message>
     <message>

--- a/qstardict/translations/qstardict-zh_CN.ts
+++ b/qstardict/translations/qstardict-zh_CN.ts
@@ -431,7 +431,7 @@
     </message>
     <message>
         <location filename="../settingsdialog.ui" line="88"/>
-        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be writen to stdin of speech process.</source>
+        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be written to stdin of speech process.</source>
         <translation></translation>
     </message>
     <message>
@@ -563,7 +563,7 @@
     <message>
         <location filename="../settingsdialog.ui" line="452"/>
         <location filename="../settingsdialog.ui" line="577"/>
-        <source>Apperance</source>
+        <source>Appearance</source>
         <translation>外观</translation>
     </message>
     <message>

--- a/qstardict/translations/qstardict-zh_TW.ts
+++ b/qstardict/translations/qstardict-zh_TW.ts
@@ -327,7 +327,7 @@
         <translation>使用如下指令發音</translation>
     </message>
     <message>
-        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be writen to stdin of speech process.</source>
+        <source>Enter cmd for the speaching program.&lt;br&gt;If cmd contains &quot;%s&quot; it will be replaced to word, else word will be written to stdin of speech process.</source>
         <translation></translation>
     </message>
     <message>
@@ -427,7 +427,7 @@
         <translation>當未找到字時顯示</translation>
     </message>
     <message>
-        <source>Apperance</source>
+        <source>Appearance</source>
         <translation>外觀</translation>
     </message>
     <message>


### PR DESCRIPTION
As suggested in https://bugs.debian.org/888807, I'm filing trying to upstream some fixes for minor issues in qstardict src. Here are some fixes for typos and desktop file.