### PR TITLE
Handle the 'h' identifier for html

### DIFF
--- a/plugins/stardict/stardict.cpp
+++ b/plugins/stardict/stardict.cpp
@@ -259,6 +259,7 @@ QString StarDict::parseData(const char *data, int dictIndex, bool htmlSpaces, bo
 			case 'm':
 			case 'l':
 			case 'g':
+			case 'h':
 			{
 				QString str = QString::fromUtf8(ptr);
 				ptr += str.toUtf8().length() + 1;


### PR DESCRIPTION
An 'h' character indicates that what follows is html. Append it to the
result without modification. (Previously, 'h' was not handled, meaning
that it would start discarding characters from the html until it reached
one it recognised, often resulting in a broken first html tag.)